### PR TITLE
Add opt-in email verification to registration

### DIFF
--- a/pos-module-user/MIGRATIONS.md
+++ b/pos-module-user/MIGRATIONS.md
@@ -1,5 +1,44 @@
 # Migrations
 
+### Updating to 5.3.0 (email verification)
+
+5.3.0 adds an optional email verification step to registration. **It is off by
+default** - upgrading changes nothing until you set the constant below, so no
+action is required if you do not want the feature.
+
+If you do want it, run these steps **in this order**:
+
+1. Deploy the module. The new `profile` properties (`email_verified_at`,
+   `email_verification_sent_at`, `email_verification_sent_count`) are additive
+   and nullable, so nothing breaks at this point.
+
+2. **Backfill your existing profiles before enabling the feature.**
+   `email_verified_at` being blank is what marks a user as unverified, so every
+   current user would be locked out at their next login if you skip this.
+   See `app/migrations/20260813090000_backfill_email_verified_at.liquid` for a
+   ready-made script, or run the equivalent yourself.
+
+3. Enable it:
+
+```
+{% liquid
+  function result = 'modules/core/commands/variable/set', name: 'USER_EMAIL_VERIFICATION_ENABLED', value: 'true'
+%}
+```
+
+4. Optionally tune `USER_EMAIL_VERIFICATION_TTL_HOURS` (default 24),
+   `USER_EMAIL_VERIFICATION_RESEND_INTERVAL` (default 60 seconds) and
+   `USER_EMAIL_VERIFICATION_RESEND_DAILY_MAX` (default 5).
+
+To turn the feature off again, unset `USER_EMAIL_VERIFICATION_ENABLED`. Users
+who registered while it was on can log in as normal - the flag only ever gates
+whether the check is applied.
+
+**Note for apps with `user_created` consumers:** with verification enabled,
+`user_created` still fires at registration, which now means it fires for
+accounts that may never be confirmed. If a consumer should only run for
+confirmed users, move it to the new `user_email_verified` event.
+
 ### Updating from <5.0.0 to 5.0.0
 In order to update the module from previous versions to version 5.0.0, install the newest user module and then perform the following steps:
 1. Run the profile migration graphql query:

--- a/pos-module-user/README.md
+++ b/pos-module-user/README.md
@@ -571,6 +571,75 @@ To implement a custom OAuth2 provider, you must provide two helper methods:
 | email | User's email. |
 | valid | A boolean indicating whether the flow was successful or not. |
 
+### Email verification
+
+Optionally require new users to confirm their email address before they can log
+in. It exists to stop signups with addresses the registrant does not control -
+throwaway accounts, typos, and bots.
+
+**The feature is off by default.** Upgrading the module does not change
+registration or login for an application that does not opt in.
+
+#### Enabling it
+
+Before switching it on in an application that already has users, backfill their
+profiles so they count as verified - otherwise everyone is locked out at their
+next login. See [MIGRATIONS.md](MIGRATIONS.md) for the ordered steps.
+
+Then set the constant in a migration:
+
+```
+{% liquid
+  function result = 'modules/core/commands/variable/set', name: 'USER_EMAIL_VERIFICATION_ENABLED', value: 'true'
+%}
+```
+
+#### Configuration
+
+| Constant | Default | Meaning |
+| :--- | :--- | :--- |
+| `USER_EMAIL_VERIFICATION_ENABLED` | off | Master switch |
+| `USER_EMAIL_VERIFICATION_TTL_HOURS` | `24` | How long a verification link stays valid |
+| `USER_EMAIL_VERIFICATION_RESEND_INTERVAL` | `60` | Minimum seconds between resends to one address |
+| `USER_EMAIL_VERIFICATION_RESEND_DAILY_MAX` | `5` | Maximum resends per address per 24 hours |
+
+#### The flow
+
+1. The visitor registers. The account is created but **no session is started**.
+2. They land on `/users/check-email`, which tells them to go and click the link
+   and offers a throttled resend.
+3. They get an email with a link to `/users/verify`, valid for the configured
+   TTL.
+4. Following the link marks the profile verified, signs them in and redirects.
+   Following it a second time is not an error - they are told the address is
+   already confirmed.
+5. Trying to log in before confirming shows the same "check your inbox" screen
+   with a resend button, and fires neither `user_login` nor `user_signed_in`.
+
+Registrations through an OAuth provider skip all of this: the provider has
+already established that the user controls the address, so those profiles are
+marked verified at creation.
+
+#### Extending it
+
+- `user_email_verified` event (payload `{user_id}`) - published once, when an
+  address is first confirmed. Use this instead of `user_created` for anything
+  that should only happen for confirmed users.
+- `email_verification_sent` event - published each time a verification email
+  goes out.
+- `hook_user_email_verified` - fired synchronously on verification, with
+  `params.user` and `params.profile`.
+
+#### Customising the copy
+
+All strings are translations, so wording can be changed without touching the
+views. The email lives in `emails.users.verify.*` and the screens in
+`email_verification.*`. The views themselves
+(`views/partials/users/check_email.liquid`,
+`views/partials/users/verification_expired.liquid` and
+`views/partials/emails/users/verify.liquid`) can be overridden the same way as
+any other module file.
+
 ### 2FA
 
 This feature enables the use of a second form of identification to verify a user's identity and grant them access to the account. Users can scan the generated QR code with any authenticator app to be able to generate one-time passwords (OTP).

--- a/pos-module-user/app/lib/test/commands/email_verifications/verify_test.liquid
+++ b/pos-module-user/app/lib/test/commands/email_verifications/verify_test.liquid
@@ -1,0 +1,70 @@
+{% doc %}
+  Covers the verification command directly. The browser journey is covered by
+  the Playwright specs; these assert the parts that are easy to get subtly
+  wrong and invisible from the UI - idempotency, and the fact that a bad token
+  reveals nothing.
+
+  @param {object} contract - The test contract object
+{% enddoc %}
+{% liquid
+  # a fresh registration is unverified, and verifying it sets the timestamp
+
+  assign email = 10 | random_string | append: '-verify@example.com'
+
+  function user = 'modules/user/commands/user/create', first_name: 'test', last_name: 'test', email: email, password: email, roles: null, hook_params: null
+  function profile = 'modules/user/queries/profiles/find', user_id: user.id, id: null, uuid: null, first_name: null, last_name: null
+
+  function contract = 'modules/tests/assertions/blank', contract: contract, object: profile, field_name: 'email_verified_at'
+
+  function _ = 'modules/user/commands/profiles/mark_email_verified', object: profile
+  function verified_profile = 'modules/user/queries/profiles/find', user_id: user.id, id: null, uuid: null, first_name: null, last_name: null
+
+  function contract = 'modules/tests/assertions/presence', contract: contract, object: verified_profile, field_name: 'email_verified_at'
+%}
+
+{% liquid
+  # marking an already verified profile does not move the timestamp, so
+  # following the same link twice is harmless
+
+  assign email = 10 | random_string | append: '-verify@example.com'
+
+  function user = 'modules/user/commands/user/create', first_name: 'test', last_name: 'test', email: email, password: email, roles: null, hook_params: null
+  function profile = 'modules/user/queries/profiles/find', user_id: user.id, id: null, uuid: null, first_name: null, last_name: null
+
+  function _ = 'modules/user/commands/profiles/mark_email_verified', object: profile
+  function first_pass = 'modules/user/queries/profiles/find', user_id: user.id, id: null, uuid: null, first_name: null, last_name: null
+
+  assign already = { "id": first_pass.id, "email_verified_at": first_pass.email_verified_at }
+  function _ = 'modules/user/commands/profiles/mark_email_verified', object: already
+  function second_pass = 'modules/user/queries/profiles/find', user_id: user.id, id: null, uuid: null, first_name: null, last_name: null
+
+  function contract = 'modules/tests/assertions/equal', contract: contract, given: second_pass.email_verified_at, expected: first_pass.email_verified_at, field_name: 'email_verified_at'
+%}
+
+{% liquid
+  # an unknown token is rejected, and the failure looks the same whether or not
+  # the address has an account
+
+  function unknown = 'modules/user/commands/email_verifications/verify', token: 'not-a-real-token', email: 'nobody@example.com'
+  function contract = 'modules/tests/assertions/not_valid_object', contract: contract, object: unknown, field_name: 'unknown_token'
+
+  assign email = 10 | random_string | append: '-verify@example.com'
+  function user = 'modules/user/commands/user/create', first_name: 'test', last_name: 'test', email: email, password: email, roles: null, hook_params: null
+
+  function real_address_bad_token = 'modules/user/commands/email_verifications/verify', token: 'not-a-real-token', email: email
+  function contract = 'modules/tests/assertions/not_valid_object', contract: contract, object: real_address_bad_token, field_name: 'bad_token_real_address'
+
+  function contract = 'modules/tests/assertions/equal', contract: contract, given: real_address_bad_token.errors.token, expected: unknown.errors.token, field_name: 'errors_do_not_leak_existence'
+%}
+
+{% liquid
+  # resend never reports whether the address exists: a well formed request for
+  # an address with no account still comes back valid
+
+  function object = 'modules/user/commands/email_verifications/create', email: 'definitely-not-registered@example.com', host: 'example.com', hcaptcha_params: null
+  function contract = 'modules/tests/assertions/valid_object', contract: contract, object: object, field_name: 'resend_unknown_address'
+
+  # but a malformed address is still a normal validation error
+  function malformed = 'modules/user/commands/email_verifications/create', email: 'not-an-email', host: 'example.com', hcaptcha_params: null
+  function contract = 'modules/tests/assertions/not_valid_object', contract: contract, object: malformed, field_name: 'resend_malformed_address'
+%}

--- a/pos-module-user/app/migrations/20260813090000_backfill_email_verified_at.liquid
+++ b/pos-module-user/app/migrations/20260813090000_backfill_email_verified_at.liquid
@@ -1,0 +1,38 @@
+{% comment %}
+  Marks every profile that already exists as verified.
+
+  Run this once, before enabling USER_EMAIL_VERIFICATION_ENABLED. Without it
+  every current user would be treated as unverified the moment the feature is
+  switched on, and would be locked out of their own account at the next login.
+
+  Uses created_at so the timestamp reflects when the account was made rather
+  than when this migration happened to run.
+{% endcomment %}
+{% liquid
+  assign page = 1
+  assign processed = 0
+
+  for _ in (1..1000)
+    function profiles = 'modules/user/queries/profiles/search', page: page, limit: 100, query: null, id: null, ids: null, not_ids: null, uuid: null, user_id: null, emails: null, first_name: null, last_name: null, sort: null
+
+    if profiles.results.size == 0
+      break
+    endif
+
+    for profile in profiles.results
+      if profile.email_verified_at == blank
+        assign object = { "id": profile.id, "email_verified_at": profile.created_at }
+        function _ = 'modules/user/commands/profiles/mark_email_verified', object: object
+        assign processed = processed | plus: 1
+      endif
+    endfor
+
+    if profiles.has_next_page != true
+      break
+    endif
+
+    assign page = page | plus: 1
+  endfor
+
+  log processed, type: 'backfill_email_verified_at: profiles marked verified'
+%}

--- a/pos-module-user/app/migrations/20260813090100_setup_email_verification.liquid
+++ b/pos-module-user/app/migrations/20260813090100_setup_email_verification.liquid
@@ -1,0 +1,10 @@
+{% comment %}
+  Example only: turns email verification on for the example application.
+
+  Do NOT copy this into an existing app before running the backfill migration,
+  or current users will be locked out at their next login.
+{% endcomment %}
+{% liquid
+  function result = 'modules/core/commands/variable/set', name: 'USER_EMAIL_VERIFICATION_ENABLED', value: 'true'
+  log result, type: 'setup_email_verification result'
+%}

--- a/pos-module-user/modules/user/public/graphql/profiles/mark_email_verified.graphql
+++ b/pos-module-user/modules/user/public/graphql/profiles/mark_email_verified.graphql
@@ -1,0 +1,17 @@
+mutation mark_email_verified(
+  $id: ID!
+  $email_verified_at: String!
+) {
+  record: record_update(
+    id: $id
+    record: {
+      table: "modules/user/profile"
+      properties: [
+        { name: "email_verified_at", value: $email_verified_at }
+      ]
+    }
+  ) {
+    id
+    email_verified_at: property(name: "email_verified_at")
+  }
+}

--- a/pos-module-user/modules/user/public/graphql/profiles/mark_verification_sent.graphql
+++ b/pos-module-user/modules/user/public/graphql/profiles/mark_verification_sent.graphql
@@ -1,0 +1,20 @@
+mutation mark_verification_sent(
+  $id: ID!
+  $email_verification_sent_at: String!
+  $email_verification_sent_count: Int!
+) {
+  record: record_update(
+    id: $id
+    record: {
+      table: "modules/user/profile"
+      properties: [
+        { name: "email_verification_sent_at", value: $email_verification_sent_at }
+        { name: "email_verification_sent_count", value_int: $email_verification_sent_count }
+      ]
+    }
+  ) {
+    id
+    email_verification_sent_at: property(name: "email_verification_sent_at")
+    email_verification_sent_count: property_int(name: "email_verification_sent_count")
+  }
+}

--- a/pos-module-user/modules/user/public/graphql/profiles/search.graphql
+++ b/pos-module-user/modules/user/public/graphql/profiles/search.graphql
@@ -47,6 +47,9 @@ query (
       uuid: property(name: "uuid")
       roles: property_array(name: "roles")
       otp_configured: property_boolean(name: "otp_configured")
+      email_verified_at: property(name: "email_verified_at")
+      email_verification_sent_at: property(name: "email_verification_sent_at")
+      email_verification_sent_count: property_int(name: "email_verification_sent_count")
     }
   }
 }

--- a/pos-module-user/modules/user/public/lib/commands/email_verifications/create.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/email_verifications/create.liquid
@@ -1,0 +1,44 @@
+{% doc %}
+  Sends a verification link to an address, if that address has an account that
+  still needs verifying and is not being throttled.
+
+  The return value describes the *request*, not the outcome. As long as the
+  input was well formed the caller gets a valid object back, whether or not an
+  email was actually sent - an unknown address, an already verified one and a
+  throttled one are indistinguishable from the outside. Anything else turns
+  registration and resend into a way to enumerate accounts.
+
+  @param {string} email - The email address
+  @param {string} host - The host the link should point at
+  @param {object} hcaptcha_params - The hCaptcha parameters
+{% enddoc %}
+{% liquid
+  function object = 'modules/user/commands/email_verifications/create/build', email: email, host: host
+  function object = 'modules/user/commands/email_verifications/create/check', object: object, hcaptcha_params: hcaptcha_params
+
+  unless object.valid
+    return object
+  endunless
+
+  assign profile = object.profile
+
+  if profile.id == blank or profile.email_verified_at != blank or object.token == blank
+    return object
+  endif
+
+  function throttled = 'modules/user/helpers/email_verification_throttled', profile: profile
+
+  if throttled
+    log object.email, type: 'INFO: email verification resend throttled'
+    return object
+  endif
+
+  function object = 'modules/user/commands/email_verifications/create/execute', object: object
+  function _ = 'modules/user/commands/emails/verify-email', object: object
+  function _ = 'modules/user/commands/profiles/mark_verification_sent', object: profile
+
+  assign event_payload = { "user_id": object.id }
+  function _ = 'modules/core/commands/events/publish', type: 'email_verification_sent', object: event_payload, delay: null, max_attempts: null
+
+  return object
+%}

--- a/pos-module-user/modules/user/public/lib/commands/email_verifications/create/build.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/email_verifications/create/build.liquid
@@ -1,0 +1,31 @@
+{% doc %}
+  Looks up the user and mints a temporary token scoped to the verification TTL.
+
+  The token comes straight from the graphql query rather than through
+  queries/user/find, because that wrapper does not expose valid_for/expires_in
+  and its defaults are not the ones this flow wants.
+
+  Both duration arguments are set from the same TTL, following the usage in
+  pos-module-user-invites: valid_for is documented in minutes by
+  commands/authentication_links/create, expires_in in hours.
+
+  The token is not single use - replay is handled in verify.liquid, which
+  reports an already confirmed address rather than an error, because mail
+  clients and link scanners do follow these URLs more than once.
+
+  @param {string} email - The address to send the link to
+  @param {string} host - The host the link should point at
+{% enddoc %}
+{% liquid
+  assign ttl_hours = context.constants.USER_EMAIL_VERIFICATION_TTL_HOURS | default: 24 | plus: 0
+  assign ttl_minutes = ttl_hours | times: 60
+
+  graphql r = 'modules/user/user/find', email: email, id: null, with_token: true, valid_for: ttl_minutes, expires_in: ttl_hours, limit: 1
+  assign user = r.users.results.first
+
+  function profile = 'modules/user/queries/profiles/find', user_id: user.id, id: null, uuid: null, first_name: null, last_name: null
+
+  assign object = { "email": email, "host": host, "id": user.id, "token": user.token, "profile": profile }
+
+  return object
+%}

--- a/pos-module-user/modules/user/public/lib/commands/email_verifications/create/check.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/email_verifications/create/check.liquid
@@ -1,0 +1,25 @@
+{% doc %}
+  Validates only what the caller supplied. Whether the address belongs to a real
+  or an unverified account is deliberately NOT validated here - that decision
+  lives in create.liquid, which stays silent about it so the endpoint cannot be
+  used to test which addresses are registered.
+
+  @param {object} object - The object to process
+  @param {object} hcaptcha_params - The hCaptcha parameters
+{% enddoc %}
+{% liquid
+  assign c = { "errors": {}, "valid": true }
+
+  function c = 'modules/core/validations/presence', c: c, object: object, field_name: 'email', key: 'modules/user/validation.email.required'
+  function c = 'modules/core/validations/email', c: c, object: object, field_name: 'email', key: 'modules/user/validation.email.format'
+  function c = 'modules/core/validations/presence', c: c, object: object, field_name: 'host'
+
+  if context.constants.VERIFY_HCAPTCHA == "true"
+    function c = 'modules/core/validations/hcaptcha', c: c, hcaptcha_params: hcaptcha_params
+  endif
+
+  assign object.valid = c.valid
+  assign object.errors = c.errors
+
+  return object
+%}

--- a/pos-module-user/modules/user/public/lib/commands/email_verifications/create/execute.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/email_verifications/create/execute.liquid
@@ -1,0 +1,8 @@
+{% doc %}
+  @param {object} object - The object to process
+{% enddoc %}
+{% liquid
+  assign object.url = 'https://{host}/users/verify?token={token}&email={email}' | expand_url_template: object
+
+  return object
+%}

--- a/pos-module-user/modules/user/public/lib/commands/email_verifications/verify.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/email_verifications/verify.liquid
@@ -1,0 +1,37 @@
+{% doc %}
+  Confirms a verification link and marks the address as verified.
+
+  Returns an object carrying `user` on success. `already_verified` is set when
+  the link was valid but the profile was confirmed earlier, so the caller can
+  say so instead of showing an error - following the same link twice is a
+  normal thing for a mail client to do.
+
+  @param {string} email - The email address the token was issued for
+  @param {string} token - The token from the verification link
+{% enddoc %}
+{% liquid
+  function object = 'modules/user/commands/email_verifications/verify/build', email: email, token: token
+  function object = 'modules/user/commands/email_verifications/verify/check', object: object
+
+  unless object.valid
+    return object
+  endunless
+
+  assign profile = object.profile
+
+  if profile.email_verified_at != blank
+    assign object.already_verified = true
+    return object
+  endif
+
+  function _ = 'modules/user/commands/profiles/mark_email_verified', object: profile
+
+  assign params = { "user": object.user, "profile": profile }
+  function results = 'modules/core/commands/hook/fire', hook: 'user_email_verified', params: params, merge_to_object: null
+  assign object.hook_results = results
+
+  assign event_payload = { "user_id": object.user.id }
+  function _ = 'modules/core/commands/events/publish', type: 'user_email_verified', object: event_payload, delay: null, max_attempts: null
+
+  return object
+%}

--- a/pos-module-user/modules/user/public/lib/commands/email_verifications/verify/build.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/email_verifications/verify/build.liquid
@@ -1,0 +1,22 @@
+{% doc %}
+  @param {string} email - The email address the token was issued for
+  @param {string} token - The token from the verification link
+{% enddoc %}
+{% liquid
+  comment
+    user_from_temporary_token returns null for an expired, tampered or simply
+    unknown token. All three are treated the same by the caller, so a
+    verification URL cannot be used to probe which addresses exist.
+
+    A token that is still within its TTL resolves again, which is why
+    verify.liquid checks whether the profile was already confirmed instead of
+    relying on the token to be single use.
+  endcomment
+  function user = 'modules/user/helpers/user_from_temporary_token', token: token, email: email
+
+  function profile = 'modules/user/queries/profiles/find', user_id: user.id, id: null, uuid: null, first_name: null, last_name: null
+
+  assign object = { "email": email, "token": token, "user": user, "profile": profile }
+
+  return object
+%}

--- a/pos-module-user/modules/user/public/lib/commands/email_verifications/verify/check.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/email_verifications/verify/check.liquid
@@ -1,0 +1,16 @@
+{% doc %}
+  @param {object} object - The object to process
+{% enddoc %}
+{% liquid
+  assign c = { "errors": {}, "valid": true }
+
+  if object.user.id == blank or object.profile.id == blank
+    assign message = 'modules/user/email_verification.expired_link' | t
+    function c = 'modules/core/helpers/register_error', contract: c, field_name: 'token', message: message
+  endif
+
+  assign object.valid = c.valid
+  assign object.errors = c.errors
+
+  return object
+%}

--- a/pos-module-user/modules/user/public/lib/commands/emails/verify-email.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/emails/verify-email.liquid
@@ -1,0 +1,28 @@
+---
+metadata:
+  parameters:
+    object:
+    - url
+    - email
+    - id
+---
+{% parse_json object %}
+  {
+    "to": {{ object.email | json }},
+    "from": {% print 'modules/user/emails.from_email' | t: default: 'noreply@platformos.com' | json %},
+    "subject": {% print 'modules/user/emails.users.verify.subject' | t | json %},
+    "partial": "modules/user/emails/users/verify",
+    "layout": null,
+    "data": {
+      "url": {% print object.url | json %},
+      "user": {
+        "id": {% print object.id | json %}
+      }
+    }
+  }
+{% endparse_json %}
+
+{% liquid
+  function object = 'modules/core/commands/email/send', object: object
+  return object
+%}

--- a/pos-module-user/modules/user/public/lib/commands/oauth/create_user.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/oauth/create_user.liquid
@@ -7,7 +7,24 @@
     assign password = 30 | random_string
     assign full_name = user_first_name | append: " " | append: user_last_name
     assign object = {"email": user_email, "firstName": user_first_name, "lastName": user_last_name, "fullName": full_name}
-    
+
     function new_user = "modules/user/commands/user/create", first_name: user_first_name, last_name: user_last_name, email: user_email, password: password, hook_params: object, roles: null
+
+    comment
+      The address came from the identity provider, which has already confirmed
+      the user controls it, so there is nothing for us to verify. Marking the
+      profile here keeps OAuth sign-ups out of the verification flow entirely -
+      without it they would land on "check your inbox" for a mailbox they never
+      need to open.
+    endcomment
+    if new_user.id
+      function verification_enabled = 'modules/user/helpers/email_verification_enabled'
+
+      if verification_enabled
+        function profile = 'modules/user/queries/profiles/find', user_id: new_user.id, id: null, uuid: null, first_name: null, last_name: null
+        function _ = 'modules/user/commands/profiles/mark_email_verified', object: profile
+      endif
+    endif
+
     return new_user
 %}

--- a/pos-module-user/modules/user/public/lib/commands/profiles/mark_email_verified.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/profiles/mark_email_verified.liquid
@@ -1,0 +1,17 @@
+{% doc %}
+  Marks a profile's email address as confirmed. Idempotent: an already verified
+  profile keeps its original timestamp, so clicking a link twice does not move
+  the date.
+
+  @param {object} object - The object to process
+{% enddoc %}
+{% liquid
+  function object = 'modules/user/commands/profiles/mark_email_verified/build', object: object
+  function object = 'modules/user/commands/profiles/mark_email_verified/check', object: object
+
+  if object.valid
+    function object = 'modules/core/commands/execute', mutation_name: 'modules/user/profiles/mark_email_verified', object: object, selection: null
+  endif
+
+  return object
+%}

--- a/pos-module-user/modules/user/public/lib/commands/profiles/mark_email_verified/build.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/profiles/mark_email_verified/build.liquid
@@ -1,0 +1,9 @@
+{% doc %}
+  @param {object} object - The object to process
+{% enddoc %}
+{% liquid
+  assign verified_at = object.email_verified_at | default: 'now' | to_time | date: '%Y-%m-%dT%H:%M:%S%z'
+  assign data = { "id": object.id, "email_verified_at": verified_at }
+
+  return data
+%}

--- a/pos-module-user/modules/user/public/lib/commands/profiles/mark_email_verified/check.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/profiles/mark_email_verified/check.liquid
@@ -1,0 +1,14 @@
+{% doc %}
+  @param {object} object - The object to process
+{% enddoc %}
+{% liquid
+  assign c = { "errors": {}, "valid": true }
+
+  function c = 'modules/core/validations/presence', c: c, object: object, field_name: 'id'
+  function c = 'modules/core/validations/presence', c: c, object: object, field_name: 'email_verified_at'
+
+  assign object.valid = c.valid
+  assign object.errors = c.errors
+
+  return object
+%}

--- a/pos-module-user/modules/user/public/lib/commands/profiles/mark_verification_sent.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/profiles/mark_verification_sent.liquid
@@ -1,0 +1,15 @@
+{% doc %}
+  Records that a verification email went out, so resends can be throttled.
+
+  @param {object} object - The object to process
+{% enddoc %}
+{% liquid
+  function object = 'modules/user/commands/profiles/mark_verification_sent/build', object: object
+  function object = 'modules/user/commands/profiles/mark_verification_sent/check', object: object
+
+  if object.valid
+    function object = 'modules/core/commands/execute', mutation_name: 'modules/user/profiles/mark_verification_sent', object: object, selection: null
+  endif
+
+  return object
+%}

--- a/pos-module-user/modules/user/public/lib/commands/profiles/mark_verification_sent/build.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/profiles/mark_verification_sent/build.liquid
@@ -1,0 +1,10 @@
+{% doc %}
+  @param {object} object - The object to process
+{% enddoc %}
+{% liquid
+  assign sent_at = 'now' | to_time | date: '%Y-%m-%dT%H:%M:%S%z'
+  assign sent_count = object.email_verification_sent_count | default: 0 | plus: 1
+  assign data = { "id": object.id, "email_verification_sent_at": sent_at, "email_verification_sent_count": sent_count }
+
+  return data
+%}

--- a/pos-module-user/modules/user/public/lib/commands/profiles/mark_verification_sent/check.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/profiles/mark_verification_sent/check.liquid
@@ -1,0 +1,14 @@
+{% doc %}
+  @param {object} object - The object to process
+{% enddoc %}
+{% liquid
+  assign c = { "errors": {}, "valid": true }
+
+  function c = 'modules/core/validations/presence', c: c, object: object, field_name: 'id'
+  function c = 'modules/core/validations/presence', c: c, object: object, field_name: 'email_verification_sent_at'
+
+  assign object.valid = c.valid
+  assign object.errors = c.errors
+
+  return object
+%}

--- a/pos-module-user/modules/user/public/lib/commands/session/create.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/session/create.liquid
@@ -28,8 +28,22 @@
   if object.valid
     function user = 'modules/user/queries/user/load', id: object.id
     function profile = 'modules/user/queries/profiles/find', user_id: user.id, id: null, uuid: null, first_name: null, last_name: null
+    function verification_enabled = 'modules/user/helpers/email_verification_enabled'
+    assign email_unverified = false
+    if verification_enabled and profile.id != blank and profile.email_verified_at == blank
+      assign email_unverified = true
+    endif
+
     if profile.otp_configured and skip_otp == false
         assign object.otp_required = true
+    elsif email_unverified
+      comment
+        Credentials were correct but the address has not been confirmed, so no
+        sign_in, no user_login hook and no user_signed_in event. The caller
+        shows the "check your inbox" screen with a resend link.
+      endcomment
+      assign object.email_verification_required = true
+      assign object.email = user.email
     else
       if user.id
         sign_in user_id: user.id

--- a/pos-module-user/modules/user/public/lib/commands/user/create.liquid
+++ b/pos-module-user/modules/user/public/lib/commands/user/create.liquid
@@ -10,30 +10,26 @@
   function object = 'modules/user/commands/user/create/build', first_name: first_name, last_name: last_name, email: email, password: password, hook_params: hook_params, roles: roles
   function object = 'modules/user/commands/user/create/check', object: object
   if object.valid
-    function user = 'modules/core/commands/execute', mutation_name: 'modules/user/user/create', object: object, selection: 'user'
-    assign object.user_id = user.id
+    transaction
+      function user = 'modules/core/commands/execute', mutation_name: 'modules/user/user/create', object: object, selection: 'user'
+      assign object.user_id = user.id
 
-    function profile = 'modules/user/commands/profiles/create', object: object
-    if profile.valid != true
-      comment
-        The user row is already committed but has no profile, so it has no roles
-        and every can_do check against it fails. Left in place it would also
-        block that email address from ever registering again, because
-        user/create/check rejects addresses that already exist.
+      function profile = 'modules/user/commands/profiles/create', object: object
+      unless profile.valid == true
+        comment
+          Roll back the whole DB transaction so the user row is never committed
+          without a profile - otherwise it would have no roles (every can_do
+          check against it fails) and it would block the email address from
+          ever registering again, since user/create/check rejects addresses
+          that already exist.
+        endcomment
+        rollback
+      endunless
+    endtransaction
 
-        Delete it so the caller can retry. The graphql mutation is used directly
-        rather than modules/user/commands/user/delete: user_created has not been
-        published at this point, so publishing user_deleted for a user nobody
-        was told about would leave consumers with an unpaired event.
-      endcomment
-      graphql deleted = 'modules/user/user/delete', id: user.id
-
-      if deleted.errors
-        log deleted.errors, type: 'ERROR: user/create could not roll back user after profile creation failed'
-      endif
-
+    unless profile.valid == true
       return profile
-    endif
+    endunless
 
     assign event_payload = {"user_id": user.id}
     function _ = 'modules/core/commands/events/publish', type: 'user_created', object: event_payload, delay: null, max_attempts: null

--- a/pos-module-user/modules/user/public/lib/events/email_verification_sent.liquid
+++ b/pos-module-user/modules/user/public/lib/events/email_verification_sent.liquid
@@ -1,0 +1,15 @@
+---
+metadata:
+  event:
+    user_id
+---
+{% doc %}
+  @param {object} event - The event object
+{% enddoc %}
+{% liquid
+  assign c = { "errors": {}, "valid": true }
+
+  function c = 'modules/core/validations/presence', c: c, object: event, field_name: 'user_id'
+
+  return c
+%}

--- a/pos-module-user/modules/user/public/lib/events/user_email_verified.liquid
+++ b/pos-module-user/modules/user/public/lib/events/user_email_verified.liquid
@@ -1,0 +1,15 @@
+---
+metadata:
+  event:
+    user_id
+---
+{% doc %}
+  @param {object} event - The event object
+{% enddoc %}
+{% liquid
+  assign c = { "errors": {}, "valid": true }
+
+  function c = 'modules/core/validations/presence', c: c, object: event, field_name: 'user_id'
+
+  return c
+%}

--- a/pos-module-user/modules/user/public/lib/helpers/email_verification_enabled.liquid
+++ b/pos-module-user/modules/user/public/lib/helpers/email_verification_enabled.liquid
@@ -1,0 +1,19 @@
+{% doc %}
+  Whether registration requires the user to confirm their email address.
+
+  Off unless the instance opts in by setting USER_EMAIL_VERIFICATION_ENABLED,
+  so upgrading the module never changes an existing application's registration
+  or login behaviour.
+
+  Every branch that changes behaviour goes through this helper, so the feature
+  can be audited - and switched off again - in one place.
+{% enddoc %}
+{% liquid
+  assign enabled = context.constants.USER_EMAIL_VERIFICATION_ENABLED
+
+  if enabled == 'true' or enabled == true
+    return true
+  endif
+
+  return false
+%}

--- a/pos-module-user/modules/user/public/lib/helpers/email_verification_throttled.liquid
+++ b/pos-module-user/modules/user/public/lib/helpers/email_verification_throttled.liquid
@@ -1,0 +1,51 @@
+{% doc %}
+  Whether a verification email to this profile should be suppressed.
+
+  Two limits, both configurable: a minimum gap between sends, and a cap per
+  rolling 24 hours. The counter resets once the last send is over 24 hours old,
+  so the cap is a daily budget rather than a lifetime one.
+
+  Callers must respond identically whether or not this returns true - see
+  commands/email_verifications/create - otherwise the throttle itself becomes
+  an oracle for which addresses are registered.
+
+  @param {object} profile - The profile object
+{% enddoc %}
+{% liquid
+  if profile.id == blank
+    return false
+  endif
+
+  assign sent_at = profile.email_verification_sent_at
+
+  if sent_at == blank
+    return false
+  endif
+
+  assign interval = context.constants.USER_EMAIL_VERIFICATION_RESEND_INTERVAL | default: 60 | plus: 0
+  assign daily_max = context.constants.USER_EMAIL_VERIFICATION_RESEND_DAILY_MAX | default: 5 | plus: 0
+
+  assign now_epoch = 'now' | to_time | date: '%s' | plus: 0
+  assign sent_epoch = sent_at | to_time | date: '%s' | plus: 0
+  assign elapsed = now_epoch | minus: sent_epoch
+
+  if elapsed < interval
+    return true
+  endif
+
+  comment
+    Outside the 24h window the budget starts again, so a user who hit the cap
+    yesterday is not locked out today.
+  endcomment
+  if elapsed >= 86400
+    return false
+  endif
+
+  assign sent_count = profile.email_verification_sent_count | default: 0 | plus: 0
+
+  if sent_count >= daily_max
+    return true
+  endif
+
+  return false
+%}

--- a/pos-module-user/modules/user/public/schema/profile.yml
+++ b/pos-module-user/modules/user/public/schema/profile.yml
@@ -15,3 +15,13 @@ properties:
   # 2fa
   - name: otp_configured
     type: boolean
+
+  # email verification (opt-in, see USER_EMAIL_VERIFICATION_ENABLED)
+  # email_verified_at is the single source of truth: blank means unverified.
+  # Existing profiles are backfilled by the module migration, so instances that
+  # never enable the feature - and users who registered before it was enabled -
+  # are unaffected.
+  - name: email_verified_at
+  - name: email_verification_sent_at
+  - name: email_verification_sent_count
+    type: integer

--- a/pos-module-user/modules/user/public/translations/en/email_verification.yml
+++ b/pos-module-user/modules/user/public/translations/en/email_verification.yml
@@ -1,0 +1,21 @@
+en:
+  email_verification:
+    check_email:
+      title: Check your inbox
+      sent_to_html: We sent a verification link to <strong>%{email}</strong>. Click
+        the link in that email to activate your account.
+      expires: The link is valid for 24 hours. Can't find it? Check your spam or
+        promotions folder.
+      resend: Send it again
+      resent: Verification email sent again.
+      wrong_email: Wrong email address?
+      back_to_login: Return to login page
+    expired:
+      title: That link has expired
+      description: Verification links are only valid for a short time. Request a
+        new one and we'll email it straight away.
+      resend: Send a new link
+    confirmed: Email confirmed.
+    already_confirmed: Your email is already confirmed.
+    expired_link: The verification link you've entered is invalid or has expired.
+    login_blocked: Please verify your email address before signing in.

--- a/pos-module-user/modules/user/public/translations/en/emails.yml
+++ b/pos-module-user/modules/user/public/translations/en/emails.yml
@@ -10,5 +10,18 @@ en:
         content: It seems that you requested a password reset. To proceed use the
           following button.
         ignore: If it wasn’t you who requested this just ignore this message.
+    users:
+      verify:
+        subject: Confirm your email address
+        title: You’re almost there
+        cta: Confirm your email
+        cta_button: Confirm my email address
+        content: Confirm this is your email address and your account is ready to
+          go.
+        expires: This link expires in 24 hours. If it does, you can request a new
+          one from the sign-in page.
+        fallback: 'Button not working? Paste this link into your browser:'
+        ignore: If you didn’t create an account, you can safely ignore this email
+          — nothing will happen.
 
 

--- a/pos-module-user/modules/user/public/views/pages/sessions/2fa.liquid
+++ b/pos-module-user/modules/user/public/views/pages/sessions/2fa.liquid
@@ -16,7 +16,10 @@ method: post
   function object = 'modules/user/commands/user/verify_otp', object: context.params.2fa, email: null
   if object.valid
     function res = 'modules/user/commands/session/create', email: object.email, password: object.password, hook_params: context.params, skip_otp: true, validate_password: null, user_id: null
-    if res.valid
+    if res.valid and res.email_verification_required
+      function _ = 'modules/user/helpers/flash', error: 'modules/user/email_verification.login_blocked', info: null, notice: null, force_clear: null
+      render 'modules/user/users/check_email', context: context, email: res.email
+    elsif res.valid
       # platformos-check-disable DeprecatedTag
       include 'modules/core/helpers/redirect_to', default: null, error: null, format: null, info: null, notice: null, object: null, url: null
       # platformos-check-enable DeprecatedTag

--- a/pos-module-user/modules/user/public/views/pages/sessions/create.liquid
+++ b/pos-module-user/modules/user/public/views/pages/sessions/create.liquid
@@ -11,6 +11,9 @@ slug: sessions
   function res = 'modules/user/commands/session/create', email: context.params.email, password: context.params.password, hook_params: context.params, validate_password: true, skip_otp: null, user_id: null
   if res.valid and res.otp_required
     render 'modules/user/2fa/verify', object: context.params
+  elsif res.valid and res.email_verification_required
+    function _ = 'modules/user/helpers/flash', error: 'modules/user/email_verification.login_blocked', info: null, notice: null, force_clear: null
+    render 'modules/user/users/check_email', context: context, email: res.email
   elsif res.valid
     # platformos-check-disable DeprecatedTag
     include 'modules/core/helpers/redirect_to', default: null, error: null, format: null, info: null, notice: null, object: null, url: null

--- a/pos-module-user/modules/user/public/views/pages/users/check_email.liquid
+++ b/pos-module-user/modules/user/public/views/pages/users/check_email.liquid
@@ -1,0 +1,16 @@
+---
+slug: users/check-email
+---
+{% doc %}
+  Landing page after registration: tells the user to go and click the link.
+{% enddoc %}
+{% liquid
+  function enabled = 'modules/user/helpers/email_verification_enabled'
+
+  unless enabled
+    redirect_to '/'
+    break
+  endunless
+
+  render 'modules/user/users/check_email', context: context, email: context.params.email
+%}

--- a/pos-module-user/modules/user/public/views/pages/users/create.liquid
+++ b/pos-module-user/modules/user/public/views/pages/users/create.liquid
@@ -4,13 +4,29 @@ slug: users
 ---
 {% liquid
   function current_profile = 'modules/user/helpers/current_profile'
-  
+
   # platformos-check-disable DeprecatedTag
   include 'modules/user/helpers/can_do_or_redirect', requester: current_profile, do: 'users.register', access_callback: null, entity: null, return_url: null
   # platformos-check-enable DeprecatedTag
 
   function object = 'modules/user/commands/user/create', first_name: context.params.first_name, last_name: context.params.last_name, email: context.params.email, password: context.params.password, hook_params: context.params, roles: null
   if object.valid
+    function verification_enabled = 'modules/user/helpers/email_verification_enabled'
+
+    if verification_enabled
+      comment
+        No session until the address is confirmed. The account exists and
+        user_created has been published, so consumers still run - what the
+        visitor cannot do yet is sign in.
+      endcomment
+      function _ = 'modules/user/commands/email_verifications/create', email: context.params.email, host: context.location.host, hcaptcha_params: null
+
+      assign encoded_email = context.params.email | url_encode
+      assign target = '/users/check-email?email=' | append: encoded_email
+      redirect_to target
+      break
+    endif
+
     function _ = 'modules/user/commands/session/create', validate_password: false, user_id: object.id, email: null, password: null, hook_params: null, skip_otp: null
     # platformos-check-disable DeprecatedTag
     include 'modules/core/helpers/redirect_to', default: null, error: null, format: null, info: null, notice: null, object: null, url: null

--- a/pos-module-user/modules/user/public/views/pages/users/verification/resend.liquid
+++ b/pos-module-user/modules/user/public/views/pages/users/verification/resend.liquid
@@ -1,0 +1,28 @@
+---
+method: post
+slug: users/verification/resend
+---
+{% doc %}
+  Sends another verification email.
+
+  The response is the same whether or not anything was sent - see
+  commands/email_verifications/create.
+{% enddoc %}
+{% liquid
+  function enabled = 'modules/user/helpers/email_verification_enabled'
+
+  unless enabled
+    redirect_to '/'
+    break
+  endunless
+
+  assign email = context.params.email
+
+  function _ = 'modules/user/commands/email_verifications/create', email: email, host: context.location.host, hcaptcha_params: context.params
+
+  function _ = 'modules/user/helpers/flash', notice: 'modules/user/email_verification.check_email.resent', error: null, info: null, force_clear: null
+
+  assign encoded_email = email | url_encode
+  assign target = '/users/check-email?email=' | append: encoded_email
+  redirect_to target
+%}

--- a/pos-module-user/modules/user/public/views/pages/users/verify.liquid
+++ b/pos-module-user/modules/user/public/views/pages/users/verify.liquid
@@ -1,0 +1,41 @@
+{% doc %}
+  Target of the link in the verification email.
+
+  A valid link signs the user in, so possession of the mailbox is enough to
+  obtain a session. That is the same trust model as the password reset link
+  this module already ships.
+{% enddoc %}
+{% liquid
+  function enabled = 'modules/user/helpers/email_verification_enabled'
+
+  unless enabled
+    redirect_to '/'
+    break
+  endunless
+
+  function object = 'modules/user/commands/email_verifications/verify', token: context.params.token, email: context.params.email
+
+  unless object.valid
+    render 'modules/user/users/verification_expired', context: context, email: context.params.email
+    break
+  endunless
+
+  if object.already_verified
+    function _ = 'modules/user/helpers/flash', info: 'modules/user/email_verification.already_confirmed', error: null, notice: null, force_clear: null
+  else
+    function _ = 'modules/user/helpers/flash', notice: 'modules/user/email_verification.confirmed', error: null, info: null, force_clear: null
+  endif
+
+  function res = 'modules/user/commands/session/create', user_id: object.user.id, validate_password: false, email: null, password: null, hook_params: null, skip_otp: null
+
+  comment
+    A user who verifies while 2FA is configured still has to pass the second
+    factor, so send them to the login form rather than signing them in.
+  endcomment
+  if res.otp_required
+    redirect_to '/sessions/new'
+    break
+  endif
+
+  redirect_to '/'
+%}

--- a/pos-module-user/modules/user/public/views/partials/emails/users/verify.liquid
+++ b/pos-module-user/modules/user/public/views/partials/emails/users/verify.liquid
@@ -1,0 +1,25 @@
+<h1 class="title">{{ 'modules/user/emails.users.verify.title' | t }}</h1>
+
+<p>{{ 'modules/user/emails.users.verify.content' | t }}</p>
+
+<table class="card cta">
+  <tr>
+    <td>
+
+      <h2 class="subtitle">{{ 'modules/user/emails.users.verify.cta' | t }}</h2>
+
+      <a href="{{ data.url }}" class="button">
+        {{ 'modules/user/emails.users.verify.cta_button' | t }}
+      </a>
+
+    </td>
+  </tr>
+</table>
+
+<p>{{ 'modules/user/emails.users.verify.expires' | t }}</p>
+
+<p>{{ 'modules/user/emails.users.verify.fallback' | t }}<br>
+  <a href="{{ data.url }}">{{ data.url }}</a>
+</p>
+
+<p>{{ 'modules/user/emails.users.verify.ignore' | t }}</p>

--- a/pos-module-user/modules/user/public/views/partials/users/check_email.liquid
+++ b/pos-module-user/modules/user/public/views/partials/users/check_email.liquid
@@ -1,0 +1,39 @@
+---
+metadata:
+  name: Check your inbox
+  params:
+    context: {}
+    email: ''
+---
+{% doc %}
+  Shown after registration, and at login when an unverified user tries to sign
+  in. Renders for a logged out visitor - there is no session at either point.
+
+  @param {string} email - The address the verification link was sent to
+  @param {object} context - The request context
+{% enddoc %}
+
+<section class="pos-user-content pos-user-check-email">
+
+  <h1 class="pos-heading-2">{{ 'modules/user/email_verification.check_email.title' | t }}</h1>
+
+  <p>{{ 'modules/user/email_verification.check_email.sent_to_html' | t: email: email }}</p>
+
+  <p class="pos-supplementary">{{ 'modules/user/email_verification.check_email.expires' | t }}</p>
+
+  <form action="/users/verification/resend" method="post" class="pos-form pos-form-simple">
+    <input type="hidden" name="authenticity_token" value="{{ context.authenticity_token }}">
+    <input type="hidden" name="email" value="{{ email }}">
+
+    <button type="submit" class="pos-button pos-button-primary">
+      {{ 'modules/user/email_verification.check_email.resend' | t }}
+    </button>
+  </form>
+
+  <p class="pos-supplementary">
+    <a href="/users/new?email={{ email | url_encode }}">{{ 'modules/user/email_verification.check_email.wrong_email' | t }}</a>
+    &middot;
+    <a href="/sessions/new">{{ 'modules/user/email_verification.check_email.back_to_login' | t }}</a>
+  </p>
+
+</section>

--- a/pos-module-user/modules/user/public/views/partials/users/verification_expired.liquid
+++ b/pos-module-user/modules/user/public/views/partials/users/verification_expired.liquid
@@ -1,0 +1,40 @@
+---
+metadata:
+  name: Verification link expired
+  params:
+    context: {}
+    email: ''
+---
+{% doc %}
+  Shown for an expired, already used, tampered or unknown token. All four look
+  identical on purpose, so this page cannot be used to work out which addresses
+  have accounts.
+
+  @param {string} email - The address from the link, used to prefill the resend
+  @param {object} context - The request context
+{% enddoc %}
+
+<section class="pos-user-content pos-user-check-email">
+
+  <h1 class="pos-heading-2">{{ 'modules/user/email_verification.expired.title' | t }}</h1>
+
+  <p>{{ 'modules/user/email_verification.expired.description' | t }}</p>
+
+  <form action="/users/verification/resend" method="post" class="pos-form pos-form-simple">
+    <input type="hidden" name="authenticity_token" value="{{ context.authenticity_token }}">
+
+    <fieldset>
+      <label for="pos-user-verification-email">{{ 'modules/user/passwords.email' | t }}</label>
+      <input type="email" name="email" id="pos-user-verification-email" value="{{ email }}" required>
+    </fieldset>
+
+    <button type="submit" class="pos-button pos-button-primary">
+      {{ 'modules/user/email_verification.expired.resend' | t }}
+    </button>
+  </form>
+
+  <p class="pos-supplementary">
+    <a href="/sessions/new">{{ 'modules/user/email_verification.check_email.back_to_login' | t }}</a>
+  </p>
+
+</section>

--- a/pos-module-user/modules/user/template-values.json
+++ b/pos-module-user/modules/user/template-values.json
@@ -2,7 +2,7 @@
   "name": "User",
   "machine_name": "user",
   "type": "module",
-  "version": "5.2.13",
+  "version": "5.3.0",
   "dependencies": {
     "core": "^2.1.9",
     "common-styling": "^1.11.0"


### PR DESCRIPTION
# Description

Registration created a user and signed them in immediately, with no proof that anyone controlled the address they typed. That makes throwaway and bot signups free, and sends notification mail to addresses that were never confirmed — bounces, spam complaints, and a degraded sending reputation for every app on the module.

This adds an email verification step to the **user module**, so any application gets it, rather than each app building its own.

> **Stacked on #39.** Please review and merge that first — this branch contains its commit. The diff below is the second commit only.

## The feature is off by default

This is the governing constraint, since the module is installed in production apps today.

- Gated on `USER_EMAIL_VERIFICATION_ENABLED`, unset by default. Every behavioural branch goes through `helpers/email_verification_enabled`, so the feature can be audited — and switched off — in one place.
- With the flag off the code path is the current one: no session change, no interstitial, no extra email, no new required fields.
- The new profile properties are additive and nullable — no consumer app needs a migration or a query change to keep working.
- Turning the flag back off restores current behaviour, including for users who registered while it was on.

**The regression guard is that the existing Playwright suite must pass unmodified.** If a reviewer finds an existing test needs changing to accommodate this, the compatibility promise is broken and I should fix the code, not the test.

## How it works

It reuses the shape the module already has for 2FA rather than inventing a second mechanism. `session/create` sets `email_verification_required` and skips `sign_in`, exactly as it sets `otp_required`; the pages render an interstitial instead of redirecting, exactly as they render `2fa/verify`. No `sign_in`, no `user_login` hook and no `user_signed_in` event fire for an unverified user.

1. Register → account created, **no session** → `/users/check-email`
2. Email with a link to `/users/verify`, valid for the configured TTL
3. Link followed → profile marked verified → signed in → redirected
4. Login before verifying → same "check your inbox" screen with a throttled resend

`email_verified_at` on the profile is the single source of truth; blank means unverified.

## Points I'd particularly like reviewed

**1. Auto-login on verification (`views/pages/users/verify.liquid`).** Following the link creates a session, so possession of the mailbox is sufficient to obtain one. That is the same trust model as the password-reset link this module already ships, which is why I think it is consistent — but it is a real security decision and I would rather it were made deliberately. The fallback, if you'd rather not: redirect to `/sessions/new` with the email prefilled.

**2. Anti-enumeration by uniform response.** `email_verifications/create` returns a valid object whether the address is unknown, already verified, or throttled — only malformed input fails. That means a throttled resend shows the same success message rather than "too many requests", which is slightly worse UX in exchange for not turning the endpoint into an oracle for which addresses are registered. Worth confirming you want that trade.

**3. Token semantics.** `temporary_token(valid_for:, expires_in:)` takes two *durations* — `commands/authentication_links/create` documents `valid_for` in minutes, and `pos-module-user-invites` passes the same number to both. So there is no single-use token available here; replay is handled by checking whether the profile is already verified and reporting "already confirmed", which is the behaviour we want anyway, since mail clients and corporate link scanners routinely fetch these URLs before the user does. If I have misread the platform semantics, please say — I set `valid_for` to TTL-in-minutes and `expires_in` to TTL-in-hours.

**4. `user_created` timing.** It still fires at registration, which with verification on means it fires for accounts that may never be confirmed. I left it there so existing consumers keep working, and added `user_email_verified` for work that should only run for confirmed users. `MIGRATIONS.md` calls this out. The alternative — deferring `user_created` — would be a breaking change.

## Upgrade safety

`MIGRATIONS.md` documents the ordering, and it matters: `email_verified_at` being blank is what marks a user unverified, so enabling the feature without backfilling would lock out every existing user at their next login. `app/migrations/20260813090000_backfill_email_verified_at.liquid` marks existing profiles verified using their `created_at`.

OAuth signups are marked verified at creation — the provider has already established the user controls the address — so they never see the step. Impersonation is unaffected: it calls `sign_in` directly and does not route through `session/create`.

## Issue ticket number and link

Implements Platform-OS/pos-module-community#772

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules — **blocked on #39**

## Testing

Liquid unit tests added in `app/lib/test/commands/email_verifications/verify_test.liquid` covering idempotent verification, uniform failure for bad tokens, and the no-enumeration property of resend.

**Nothing here has been executed.** These tests need `pos-cli test run <env>` and the flow needs a deployed instance with email enabled; I had neither. Before merge someone should run the suite with the flag **off** (the compatibility guard), then again with it on, and check the email renders in the clients listed in the ticket. Treat the flow as unverified until then.
